### PR TITLE
Fix README formatting for selenium worker line

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ curl -X POST "http://127.0.0.1:8000/selenium" -H "Content-Type: application/json
 │   ├── main.py           # Точка входа для backend-приложения
 │   ├── routes.py         # Определения REST API маршрутов
 │   ├── admin.py          # Интерфейс администратора (sqladmin)
-│   └── selenium_worker.py# Автоматизация через браузер
+│   └── selenium_worker.py  # Автоматизация через браузер
 │
 ├── frontend/             # GUI: PySide6
 │   └── main.py           # Основная логика интерфейса


### PR DESCRIPTION
## Summary
- fix README formatting for `selenium_worker.py` in project structure block

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68418f443d14832698b30c8c3c296abc