### PR TITLE
Fix comment for sqladmin async session

### DIFF
--- a/backend/admin.py
+++ b/backend/admin.py
@@ -2,7 +2,7 @@
 
 from sqladmin import Admin, ModelView
 from backend.models import User
-from backend.database import engine, async_session_maker  # Обрати внимание
+from backend.database import engine, async_session_maker  # required so sqladmin works with the async session
 from fastapi import FastAPI
 
 app = FastAPI()


### PR DESCRIPTION
## Summary
- clarify why we import `async_session_maker` in admin module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841903f4d6083269c70f4631ec38173